### PR TITLE
Added Support For NixOS / Flakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ SRC      = src/nwm.cpp src/bar.cpp src/tiling.cpp src/systray.cpp
 OBJ      = src/nwm.o src/bar.o src/tiling.o src/systray.o
 DEPS     = src/nwm.hpp src/bar.hpp src/tiling.hpp src/config.hpp src/systray.hpp
 
-LDFLAGS  = -I/usr/include/freetype2 
+LDFLAGS  = -I/usr/include/freetype2
 LDLIBS   = -lX11 -lXft -lfreetype -lfontconfig -lXrender -lm -lXrandr
 
 PREFIX   ?= /usr/local
 BINDIR   ?= $(PREFIX)/bin
-XSESSIONSDIR ?= /usr/share/xsessions
+XSESSIONSDIR ?= $(PREFIX)/share/xsessions
 
 .PHONY: copy all install clean uninstall
 

--- a/Readme.org
+++ b/Readme.org
@@ -204,6 +204,75 @@ nix develop
 
 This provides a shell with all build tools, libraries, and useful utilities pre-installed.
 
+*** Installing on NixOS with Custom Configuration
+
+Since NWM follows the suckless philosophy (configuration through recompilation), the recommended approach is to maintain your customized NWM source in your dotfiles and use ~overrideAttrs~ to build from it.
+
+1. Copy the NWM source to your dotfiles:
+   #+begin_src bash
+   mkdir -p ~/nixos-dotfiles/config
+   git clone https://github.com/xsoder/nwm.git ~/nixos-dotfiles/config/nwm
+   #+end_src
+
+2. Edit your configuration:
+   #+begin_src bash
+   cd ~/nixos-dotfiles/config/nwm
+   # The Makefile will copy default-config.hpp to config.hpp on first build
+   make copy
+   # Now edit src/config.hpp with your customizations
+   vim src/config.hpp
+   #+end_src
+
+3. Add NWM as a flake input and use ~overrideAttrs~ in your NixOS configuration:
+
+   In your ~flake.nix~:
+   #+begin_src nix
+   {
+     inputs = {
+       nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+       nwm.url = "github:yourusername/nwm-flake";
+     };
+
+     outputs = { self, nixpkgs, nwm, ... }: {
+       nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+         system = "x86_64-linux";
+         specialArgs = { inherit nwm; };
+         modules = [ ./configuration.nix ];
+       };
+     };
+   }
+   #+end_src
+
+   In your ~configuration.nix~:
+   #+begin_src nix
+   { pkgs, nwm, ... }:
+
+   {
+     environment.systemPackages = [
+       (nwm.packages.x86_64-linux.default.overrideAttrs {
+         src = ./config/nwm;
+       })
+     ];
+
+     # Optional: Enable as a display manager session
+     services.xserver = {
+       enable = true;
+       displayManager.sessionPackages = [
+         (nwm.packages.x86_64-linux.default.overrideAttrs {
+           src = ./config/nwm;
+         })
+       ];
+     };
+   }
+   #+end_src
+
+4. Rebuild your system:
+   #+begin_src bash
+   sudo nixos-rebuild switch --flake .#yourhostname
+   #+end_src
+
+Now whenever you modify ~config/nwm/src/config.hpp~, just rebuild your system and NWM will be recompiled with your changes.
+
 * Getting Started
 
 ** Starting NWM

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  pkg-config,
+  xorg,
+  freetype,
+  fontconfig,
+  makeDesktopItem,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nwm";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    xorg.libX11
+    xorg.libXft
+    xorg.libXrender
+    xorg.libXrandr
+    freetype
+    fontconfig
+  ];
+
+  preBuild = ''
+    if [ ! -f src/config.hpp ]; then
+      cp src/default-config.hpp src/config.hpp
+      echo "Copied default-config.hpp to config.hpp"
+    fi
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CC=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  postInstall = let
+    nwmDesktopItem = makeDesktopItem rec {
+      name = finalAttrs.pname;
+      exec = name;
+      desktopName = name;
+      comment = finalAttrs.meta.description;
+    };
+  in ''
+    install -Dt $out/share/xsessions ${nwmDesktopItem}/share/applications/nwm.desktop
+  '';
+
+  passthru.providedSessions = ["nwm"];
+
+  meta = with lib; {
+    description = "A scrollable tiling window manager for X11";
+    homepage = "https://github.com/xsoder/nwm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "nwm";
+  };
+})

--- a/flake.nix
+++ b/flake.nix
@@ -7,104 +7,93 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        
-        nwm = pkgs.stdenv.mkDerivation {
-          pname = "nwm";
-          version = "0.1.0";
-          src = ./.;
-          
-          buildInputs = with pkgs; [
-            xorg.libX11
-            xorg.libXft
-            xorg.libXrender
-            fontconfig
-            freetype
-          ];
-          
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-          ];
-          
-          makeFlags = [
-            "PREFIX=$(out)"
-            "CC=${pkgs.stdenv.cc.targetPrefix}cc"
-          ];
-          
-          installPhase = ''
-            mkdir -p $out/bin
-            install -Dm755 nwm $out/bin/nwm
-          '';
-          
-          meta = with pkgs.lib; {
-            description = "A scrollable tiling window manager for X11";
-            homepage = "https://github.com/xsoder/nwm";
-            license = licenses.mit;
-            platforms = platforms.linux;
-            maintainers = [ ];
+    let
+      nixosModulesOutput = {
+        nixosModules.default = { config, lib, pkgs, ... }:
+          with lib;
+          let
+            cfg = config.services.xserver.windowManager.nwm;
+          in {
+            options.services.xserver.windowManager.nwm = {
+              enable = mkEnableOption "nwm window manager";
+              package = mkOption {
+                type = types.package;
+                default = self.packages.${pkgs.system}.default;
+                description = "nwm package to use";
+              };
+            };
+
+            config = mkIf cfg.enable {
+              services.xserver.windowManager.session = [{
+                name = "nwm";
+                start = ''
+                  ${cfg.package}/bin/nwm &
+                  waitPID=$!
+                '';
+              }];
+              environment.systemPackages = [ cfg.package ];
+            };
           };
-        };
-        
-      in
-      {
-        packages = {
-          default = nwm;
-          nwm = nwm;
-        };
-        
-        devShells.default = pkgs.mkShell {
-          name = "nwm-dev";
-          
-          packages = with pkgs; [
-            # Build tools
-            pkg-config
-            gcc
-            gnumake
-            git
-            # X11 libraries
-            xorg.libX11
-            xorg.libXft
-            xorg.libXrender
-            # Font libraries
-            fontconfig
-            freetype
-            # Fonts
-            nerd-fonts.iosevka
-            # Debugging and development
-            gdb
-            valgrind
-            # Testing tools
-            xorg.xorgserver
-            xorg.xinit
-            xorg.xev
-            xorg.xdpyinfo
-            # Utilities
-            feh
-            st
-            dmenu
-          ];
-          
-          XINERAMA = "1";
-          FREETYPEINC = "${pkgs.freetype.dev}/include/freetype2";
-          X11INC = "${pkgs.xorg.libX11.dev}/include";
-          X11LIB = "${pkgs.xorg.libX11}/lib";
-        };
-        
-        # Minimal dev shell
-        devShells.minimal = pkgs.mkShell {
-          packages = with pkgs; [
-            pkg-config
-            xorg.libX11
-            xorg.libXft
-            xorg.libXrender
-            fontconfig
-            freetype
-            gcc
-            gnumake
-          ];
-        };
-      }
-    );
+      };
+
+      systemOutputs = flake-utils.lib.eachDefaultSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+
+          nwm = pkgs.callPackage ./default.nix { };
+
+        in
+        {
+          packages = {
+            default = nwm;
+            nwm = nwm;
+          };
+
+          devShells.default = pkgs.mkShell {
+            name = "nwm-dev";
+
+            packages = with pkgs; [
+              pkg-config
+              gcc
+              gnumake
+              git
+              xorg.libX11
+              xorg.libXft
+              xorg.libXrender
+              fontconfig
+              freetype
+              nerd-fonts.iosevka
+              gdb
+              valgrind
+              xorg.xorgserver
+              xorg.xinit
+              xorg.xev
+              xorg.xdpyinfo
+              feh
+              st
+              dmenu
+            ];
+
+            XINERAMA = "1";
+            FREETYPEINC = "${pkgs.freetype.dev}/include/freetype2";
+            X11INC = "${pkgs.xorg.libX11.dev}/include";
+            X11LIB = "${pkgs.xorg.libX11}/lib";
+          };
+
+          devShells.minimal = pkgs.mkShell {
+            packages = with pkgs; [
+              pkg-config
+              xorg.libX11
+              xorg.libXft
+              xorg.libXrender
+              fontconfig
+              freetype
+              gcc
+              gnumake
+            ];
+          };
+        }
+      );
+    in
+      nixosModulesOutput // systemOutputs;
 }


### PR DESCRIPTION
# Changes for NixOS/Nix Flake Support

## Summary

Added NixOS module support via `nixosModules.default` to provide a clean, declarative way for NixOS users to use NWM as their window manager. This follows the suckless philosophy of configuration-through-recompilation while providing a Nix-native installation path.

## Changes Made

### 1. Added `default.nix`

Created a `default.nix` file that:
- Builds NWM using the existing Makefile
- Handles the `config.hpp` copying in the `preBuild` phase
- Includes all required dependencies (X11, Xft, Xrender, Xrandr, freetype, fontconfig)
- Creates and installs a desktop session file for display managers
- Supports `overrideAttrs` to point to custom source directories (for user configurations)
- Provides `passthru.providedSessions` for NixOS integration

### 2. Created NixOS Module (`nixosModules.default`)

Added a NixOS module in `flake.nix` that:
- Provides `services.xserver.windowManager.nwm` options
- Includes `enable` option to enable nwm as a window manager
- Includes `package` option with a default value that can be overridden
- Automatically registers nwm as a window manager session
- Adds nwm to system packages when enabled

This allows for a clean integration following NixOS conventions, similar to other window managers.

### 3. Updated README Documentation

Added documentation explaining:
- How to use NWM as a flake input
- How to import and use the NixOS module
- The recommended workflow for maintaining custom configurations
- How to use `overrideAttrs` to build from user-customized source

## Usage

NixOS users can now use NWM with a clean, declarative configuration:

### 1. Add NWM as a flake input

In your `flake.nix`:
```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    nwm = {
      url = "github:xsoder/nwm-";
      inputs.nixpkgs.follows = "nixpkgs";
    };
  };

  outputs = { self, nixpkgs, nwm, ... }: {
    nixosConfigurations.yourhost = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      specialArgs = { inherit nwm; };
      modules = [
        ./configuration.nix
        nwm.nixosModules.default
      ];
    };
  };
}
```

### 2. Enable and configure in your configuration.nix

```nix
{ config, lib, pkgs, nwm, ... }:

{
  services.xserver = {
    enable = true;
    windowManager.nwm = {
      enable = true;
      package = nwm.packages.${pkgs.system}.default.overrideAttrs {
        src = ./config/nwm;  # Your customized nwm source
      };
    };
  };
}
```

### 3. Maintain your customized configuration

Keep your customized nwm source in your dotfiles (e.g., `~/nixos-dotfiles/config/nwm`) and the module will build it automatically when you rebuild your system.

## Example

This is how it's used in a real configuration:

**flake.nix:**
```nix
nwm = {
  url = "github:xsoder/nwm";
  inputs.nixpkgs.follows = "nixpkgs";
};

# ...

modules = [
  ./configuration.nix
  nwm.nixosModules.default
];
```

**configuration.nix:**
```nix
services.xserver.windowManager.nwm = {
  enable = true;
  package = nwm.packages.${pkgs.system}.default.overrideAttrs {
    src = ./config/nwm;
  };
};
```

This approach respects NWM's suckless philosophy while providing a declarative, reproducible installation method that integrates cleanly with NixOS conventions.
